### PR TITLE
【release v1.1 】計画リストの削除機能追加とその他改善

### DIFF
--- a/src/assets/scss/variable.scss
+++ b/src/assets/scss/variable.scss
@@ -1,3 +1,3 @@
 $app-color: #fc471e;
 $app-header-height: 48px;
-$app-footer-height: 48px;
+$app-footer-height: 54px;

--- a/src/components/mix/mix-action-button.vue
+++ b/src/components/mix/mix-action-button.vue
@@ -4,7 +4,7 @@
       <ul class="actionContent__list">
         <li class="actionContent__item" @click="showModal">予定の追加</li>
         <li class="actionContent__item" @click="prepareDelete">予定の削除</li>
-        <li class="actionContent__item" @click="showPopup">予定リストの新規作成</li>
+        <li class="actionContent__item" @click="showPopup">計画の新規作成</li>
       </ul>
     </div>
     <add-button

--- a/src/components/mix/mix-action-button.vue
+++ b/src/components/mix/mix-action-button.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="actionButton">
-    <div :class="`actionContent${actionContent.isHidden ? ' isHidden': ''}`">
+  <div :class="`actionButton${actionContent.isHidden ? ' isHidden': ''}`">
+    <div class="actionContent">
       <ul class="actionContent__list">
-        <li class="actionContent__item" @click="showPopup">新規作成</li>
         <li class="actionContent__item" @click="showModal">予定の追加</li>
         <li class="actionContent__item" @click="prepareDelete">予定の削除</li>
+        <li class="actionContent__item" @click="showPopup">予定リストの新規作成</li>
       </ul>
     </div>
     <add-button
@@ -76,25 +76,22 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.actionContent {
+.actionButton {
   position: fixed;
   bottom: 0;
   left: 0;
   z-index: 80;
   width: 100%;
-  height: $app-footer-height;
-  background-color: $app-color;
   transform: translate(0, 0);
   transition: .3s;
-
   &.isHidden {
-    transform: translate(0, $app-footer-height);
+    transform: translate(0, 168px);
   }
+}
+.actionContent {
+  background-color: $app-color;
 
   &__list {
-    display: flex;
-    flex: 1;
-    height: 100%;
     list-style: none;
   }
   &__item {
@@ -104,7 +101,24 @@ export default {
     color: #fff;
     font-size: 14px;
     width: 100%;
-    height: 100%;
+    height: 56px;
+  }
+
+  &__item + .actionContent__item {
+    border-top: 1px solid #ac3318;
+  }
+}
+
+.actionButton {
+  /deep/ .addButton,
+  /deep/ .deleteButton {
+    position: absolute;
+    top: -70px;
+    transition: .3s;
+  }
+  &.isHidden /deep/ .addButton,
+  &.isHidden /deep/ .deleteButton {
+    top: -122px;
   }
 }
 </style>

--- a/src/components/mix/mix-action-button.vue
+++ b/src/components/mix/mix-action-button.vue
@@ -15,7 +15,6 @@
       :isShow="isDeletable"
       @click.native="confirmDelete"
     />
-    <mix-todoname-popup :isShown="isShown"/>
   </div>
 </template>
 
@@ -23,7 +22,6 @@
 import AddButton from "~/components/simple/add-button";
 import AppButton from "~/components/simple/app-button";
 import DeleteButton from "~/components/simple/delete-button";
-import MixTodonamePopup from "~/components/mix/mix-todoname-popup";
 import { mapState } from 'vuex';
 
 export default {
@@ -31,7 +29,6 @@ export default {
     AddButton,
     AppButton,
     DeleteButton,
-    MixTodonamePopup
   },
   data() {
     return {
@@ -45,9 +42,6 @@ export default {
     ...mapState('todo-item', [
       'isDeletable'
     ]),
-    ...mapState('mix-todoname-popup', [
-      'isShown'
-    ])
   },
   methods: {
     toggleState: function() {

--- a/src/components/mix/mix-action-controllers.vue
+++ b/src/components/mix/mix-action-controllers.vue
@@ -1,0 +1,108 @@
+<template>
+  <div :class="`actionControllers${actionContent.isHidden ? ' isHidden': ''}`">
+    <div class="actionContent">
+      <ul class="actionContent__list">
+        <li
+          class="actionContent__item"
+          v-for="(action, index) of actions"
+          :key="index"
+          @click="action.event">
+            {{action.name}}
+        </li>
+      </ul>
+    </div>
+    <add-button
+      :isShow="buttons.add"
+      :isActive="!actionContent.isHidden"
+      @click.native="toggleState"/>
+    <delete-button
+      :isShow="buttons.del"
+      @click.native="delAction"
+    />
+  </div>
+</template>
+
+<script>
+import AddButton from "~/components/simple/add-button";
+import DeleteButton from "~/components/simple/delete-button";
+import { mapState } from 'vuex';
+
+export default {
+  components: {
+    AddButton,
+    DeleteButton
+  },
+  props: {
+    actions: Array,
+    buttons: {
+      add: Boolean,
+      del: Boolean
+    },
+    delAction: Function,
+  },
+  data() {
+    return {
+      actionContent: {
+        isHidden: true,
+      },
+    };
+  },
+  mounted() {
+    console.log(this.index);
+  },
+  methods: {
+    toggleState: function() {
+      this.actionContent.isHidden = !this.actionContent.isHidden;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.actionControllers {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 80;
+  width: 100%;
+  transform: translate(0, 0);
+  transition: .3s;
+  &.isHidden {
+    transform: translate(0, 100%);
+  }
+}
+.actionContent {
+  background-color: $app-color;
+
+  &__list {
+    list-style: none;
+  }
+  &__item {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #fff;
+    font-size: 14px;
+    width: 100%;
+    height: 56px;
+  }
+
+  &__item + .actionContent__item {
+    border-top: 1px solid #ac3318;
+  }
+}
+
+.actionControllers {
+  /deep/ .addButton,
+  /deep/ .deleteButton {
+    position: absolute;
+    top: -70px;
+    transition: .3s;
+  }
+  &.isHidden /deep/ .addButton,
+  &.isHidden /deep/ .deleteButton {
+    top: -122px;
+  }
+}
+</style>
+

--- a/src/components/mix/mix-action-controllers.vue
+++ b/src/components/mix/mix-action-controllers.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="`actionControllers${actionContent.isHidden ? ' isHidden': ''}`">
+  <div :class="`actionControllers${isActived ? '': ' isHidden'}`">
     <div class="actionContent">
       <ul class="actionContent__list">
         <li
@@ -13,7 +13,7 @@
     </div>
     <add-button
       :isShow="buttons.add"
-      :isActive="!actionContent.isHidden"
+      :isActive="isActived"
       @click.native="toggleState"/>
     <delete-button
       :isShow="buttons.del"
@@ -34,25 +34,17 @@ export default {
   },
   props: {
     actions: Array,
-    buttons: {
-      add: Boolean,
-      del: Boolean
-    },
     delAction: Function,
   },
-  data() {
-    return {
-      actionContent: {
-        isHidden: true,
-      },
-    };
-  },
-  mounted() {
-    console.log(this.index);
+  computed: {
+    ...mapState('mix-action-controllers', [
+      'isActived',
+      'buttons',
+    ]),
   },
   methods: {
-    toggleState: function() {
-      this.actionContent.isHidden = !this.actionContent.isHidden;
+    toggleState() {
+      this.$store.commit('mix-action-controllers/isActived');
     },
   },
 };

--- a/src/components/mix/mix-modal-screen.vue
+++ b/src/components/mix/mix-modal-screen.vue
@@ -237,6 +237,7 @@ export default {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    list-style: none;
   }
   &__settingItem {
     margin-bottom: 24px;

--- a/src/components/mix/mix-todoname-popup.vue
+++ b/src/components/mix/mix-todoname-popup.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
 import AppButton from "~/components/simple/app-button";
 import ModalScreen from "~/components/simple/modal-screen";
 
@@ -26,13 +27,23 @@ export default {
   props: {
     isShown: Boolean,
   },
+  computed: {
+    ...mapState('todo-item', [
+      'currentDataKeyName',
+      'currentTodoname'
+    ]),
+  },
   methods: {
-    createNewData() {
+    async createNewData() {
       if (this.todoname) {
         const uid = this.$store.getters['user/uid'];
-        this.$store.dispatch('todo-item/createNewData', {
+        await this.$store.dispatch('todo-item/createNewData', {
           todoname: this.todoname,
           uid,
+        });
+        this.$store.commit('list/appendList', {
+          name: this.currentTodoname,
+          value: this.currentDataKeyName
         });
         this.close();
       }

--- a/src/components/mix/todo-item.vue
+++ b/src/components/mix/todo-item.vue
@@ -46,7 +46,7 @@ export default {
     background-color: #fff;
     width: 100%;
     min-height: 56px;
-    font-size: 12px;
+    font-size: 14px;
     padding: 4px;
     border: 1px solid #c4c4c4;
     &:empty {

--- a/src/components/simple/app-footer.vue
+++ b/src/components/simple/app-footer.vue
@@ -1,9 +1,15 @@
 <template>
   <footer class="appFooter">
-    <ul class="appFooter__items">
-      <li class="appFooter__item"><n-link to="/">計画内容</n-link></li>
-      <li class="appFooter__item"><n-link to="/list">計画一覧</n-link></li>
-      <li class="appFooter__item"><n-link to="/sign-out">ログアウト</n-link></li>
+    <ul :class="`appFooter__items ${currentPage}`">
+      <li :class="`appFooter__item${isTop ? ' is-selected' : '' }`">
+        <n-link to="/">計画内容</n-link>
+      </li>
+      <li :class="`appFooter__item${isList ? ' is-selected' : '' }`">
+        <n-link to="/list">計画一覧</n-link>
+      </li>
+      <li :class="`appFooter__item${isSignout ? ' is-selected' : '' }`">
+        <n-link to="/sign-out">ログアウト</n-link>
+      </li>
     </ul>
   </footer>
 </template>
@@ -15,29 +21,42 @@ export default {
       this.addStateClass(to);
     }
   },
+  data() {
+    return {
+      isTop: true,
+      isList: false,
+      isSignout: false,
+      currentPage: 'is-top',
+    }
+  },
+  mounted() {
+    this.addStateClass(this.$route);
+  },
   methods: {
     addStateClass: function(path) {
-      const items = this.$el.querySelectorAll('.appFooter__item');
-      for (const item of items) {
-        item.classList.remove('isSelected');
-      }
       switch(path.name) {
         case 'index':
-          items[0].classList.add('isSelected');
+          this.isTop = true;
+          this.isList = false;
+          this.isSignout = false;
+          this.currentPage = 'is-top';
           break
         case 'list':
-          items[1].classList.add('isSelected');
+          this.isTop = false;
+          this.isList = true;
+          this.isSignout = false;
+          this.currentPage = 'is-list';
           break
         case 'sign-out':
-          items[2].classList.add('isSelected');
+          this.isTop = false;
+          this.isList = false;
+          this.isSignout = true;
+          this.currentPage = 'is-signout';
           break
         default:
           break
       }
     }
-  },
-  mounted() {
-    this.addStateClass(this.$route);
   }
 }
 </script>
@@ -55,16 +74,36 @@ export default {
   box-shadow: #ccc 0 0 8px 2px;
 
   &__items {
+    position: relative;
     display: flex;
     list-style: none;
     height: 100%;
+    &::after {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 33.3%;
+      height: 3px;
+      background-color: $app-color;
+      transition: .2s transform ease;
+      content: '';
+    }
+    &.is-top::after {
+      transform: translate(0);
+    }
+    &.is-list::after {
+      transform: translate(100%);
+    }
+    &.is-signout::after {
+      transform: translate(200%);
+    }
   }
 
   &__item {
     flex: 1;
     height: 100%;
 
-    &.isSelected {
+    &.is-selected {
       color: $app-color;
     }
 

--- a/src/components/simple/check-icon.vue
+++ b/src/components/simple/check-icon.vue
@@ -1,0 +1,65 @@
+<template>
+  <div
+    :class="`checkIcon${isChecked ? ' is-checked': ''}`"
+    :data-id="dataSetVal"
+    @click="toggleCheckmark"
+  ></div>
+</template>
+<script>
+
+export default {
+  props: {
+    dataSetVal: String,
+  },
+  data() {
+    return {
+      isChecked: false,
+    }
+  },
+  methods: {
+    toggleCheckmark(e) {
+      this.isChecked = !this.isChecked;
+      this.$emit('emitCheckmark', {
+        isChecked: this.isChecked,
+        dataSetVal: this.dataSetVal,
+      })
+    },
+  }
+};
+</script>
+<style lang="scss" scoped>
+  .checkIcon {
+    position: relative;
+    width: 48px;
+    height: 48px;
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+    }
+
+    &::after {
+      top: 44%;
+      left: 6px;
+      width: 20px;
+      height: 10px;
+      border-left: 4px solid #ccc;
+      border-bottom: 4px solid #ccc;
+      transform:  translate(0, -50%) rotate(-45deg);
+    }
+    &::before {
+      top: 50%;
+      left: 0;
+      width: 32px;
+      height: 32px;
+      border: 2px solid #ccc;
+      transform: translate(0, -50%);
+    }
+
+    &.is-checked::after,
+    &.is-checked::before {
+      border-color: #38c970;
+    }
+  }
+</style>

--- a/src/components/simple/modal-screen.vue
+++ b/src/components/simple/modal-screen.vue
@@ -24,10 +24,11 @@ export default {
   align-items: center;
   width: 100vw;
   height: 100vh;
-  background-color: rgba(0, 0, 0, .8);
+  background-color: rgba(0, 0, 0, .75);
   opacity: 1;
   z-index: 100;
-  transition: .3s,
+  transition: .3s;
+  backdrop-filter: blur(3px);
 }
 
 // modal (transionタグの効果)開始時の style

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -66,7 +66,7 @@ export default {
         });
         this.$store.dispatch('todo-item/getTodo', {
           uid: user.uid,
-          docId: this.listData ? this.listData[0].value : '',
+          docId: this.listData ? this.listData[0].value : 'example',
         });
       } else {
         this.$router.push("/sign-in");

--- a/src/pages/list.vue
+++ b/src/pages/list.vue
@@ -11,32 +11,47 @@
           @click="switchToDo">{{ datum.name }}
         </li>
       </ul>
-      <add-button/>
     </section>
+    <mix-todoname-popup :isShown="mixTodonamePopup.isShown"/>
+    <mix-action-controllers
+      :buttons="{add: true, del: false}"
+      :actions="[
+        { name: '計画の新規作成', event: showPopup },
+        { name: '計画の削除', event:'' },
+        { name: '計画の名前変更', event:'' }
+      ]"
+    />
   </div>
 </template>
 
 <script>
 import firebase from "~/plugins/firebase";
 import AppLoadding from '~/components/simple/app-loading';
-import AddButton from '~/components/simple/add-button';
+import MixActionControllers from '~/components/mix/mix-action-controllers';
+import MixTodonamePopup from '~/components/mix/mix-todoname-popup';
 import { mapState } from 'vuex';
 
 export default {
   layout: "default",
   components: {
     AppLoadding,
-    AddButton
+    MixActionControllers,
+    MixTodonamePopup
   },
   data() {
     return {
       user: {}
     };
   },
-
+  watch: {
+    currentTodoname (val, oldVal) {
+      setTimeout(() => this.$router.push('/'), 300);
+    }
+  },
   computed: {
     ...mapState('todo-item', [
-      'currentDataKeyName'
+      'currentDataKeyName',
+      'currentTodoname'
     ]),
     ...mapState('list', [
       'data'
@@ -45,6 +60,13 @@ export default {
       'isUser',
       'uid'
     ]),
+    ...mapState('mix-todoname-popup', {
+      mixTodonamePopup: (state) => {
+        return {
+          isShown: state.isShown,
+        }
+      }
+    })
   },
 
   async mounted() {
@@ -77,6 +99,9 @@ export default {
       // console.log('component::end switchToDo');
       const docId = this.$store.getters['todo-item/docId'];
       this.$store.dispatch('todo-item/getTodo', { docId, uid: this.uid });
+    },
+    showPopup() {
+      this.$store.commit('mix-todoname-popup/show');
     }
   },
 };

--- a/src/pages/list.vue
+++ b/src/pages/list.vue
@@ -108,15 +108,22 @@ export default {
   },
   methods: {
     init() {
+      if (this.isDeletable) {
+        this.$store.commit('mix-action-controllers/initializeState');
+        this.$store.commit('list/resetDeletionData');
+        this.$store.commit('list/isDeletable');
+      }
       this.$store.dispatch('list/getList', { uid: this.uid });
     },
     switchToDo(e) {
-      this.$store.commit('todo-item/setTodoState', {
-        key: e.target.dataset.id,
-        name: e.target.innerText,
-      });
-      const docId = this.$store.getters['todo-item/docId'];
-      this.$store.dispatch('todo-item/getTodo', { docId, uid: this.uid });
+      if (this.isDeletable === false) {
+        this.$store.commit('todo-item/setTodoState', {
+          key: e.target.dataset.id,
+          name: e.target.innerText,
+        });
+        const docId = this.$store.getters['todo-item/docId'];
+        this.$store.dispatch('todo-item/getTodo', { docId, uid: this.uid });
+      }
     },
     showPopup() {
       this.$store.commit('mix-todoname-popup/show');

--- a/src/plugins/firebase-query.js
+++ b/src/plugins/firebase-query.js
@@ -3,18 +3,6 @@ import firebase from "~/plugins/firebase";
 export default class {
   constructor() {
   }
-  async getAuthState() {
-    return new Promise((resolve) => {
-      firebase.auth().onAuthStateChanged((result) => {
-        if (result) {
-          // console.log(result);
-          resolve(result);
-        } else {
-          resolve(false);
-        }
-      });
-    });
-  }
   async createNewUser(collection, docName) {
     const docRef = await firebase.firestore().collection(collection);
     // console.log(docRef);

--- a/src/plugins/util.js
+++ b/src/plugins/util.js
@@ -1,0 +1,33 @@
+export const showAlert = (() => {
+  let isShown = false;
+  return (text) => {
+    if (isShown === false) {
+      isShown = true;
+      const div = document.createElement('div');
+      const textNode = document.createTextNode(text);
+      div.setAttribute('style', `
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 300px;
+        max-width: 80%;
+        text-align: center;
+        border-radius: 8px;
+        padding: 20px;
+        background-color: #fff;
+        box-shadow: 0 4px 10px -4px rgba(0, 0, 0, .3);
+        transition: .3s opacity;
+      `);
+      div.appendChild(textNode);
+      document.body.appendChild(div);
+      setTimeout(() => {
+        div.style.opacity = 0;
+        setTimeout(() => {
+          isShown = false;
+          document.body.removeChild(div);
+        }, 300);
+      }, 2000);
+    }
+  }
+})();

--- a/src/store/list.js
+++ b/src/store/list.js
@@ -7,8 +7,10 @@ export const state = () => ({
 export const mutations = {
   setList(state, data) {
     // console.log('MUTATIONS::setList');
-    // console.log(data);
     state.data = data;
+  },
+  appendList(state, data) {
+    state.data.push(data)
   }
 }
 

--- a/src/store/list.js
+++ b/src/store/list.js
@@ -1,7 +1,9 @@
-import firebase from "~/plugins/firebase";
+import fb from "~/plugins/firebase";
 
 export const state = () => ({
   data: [],
+  isDeletable: false,
+  deletionData: [],
 });
 
 export const mutations = {
@@ -11,16 +13,55 @@ export const mutations = {
   },
   appendList(state, data) {
     state.data.push(data)
+  },
+  removeList(state, indices) {
+    for (const idx of indices) {
+      state.data.splice(idx, 1);
+    }
+  },
+  isDeletable(state) {
+    state.isDeletable = !state.isDeletable;
+  },
+  appendDeletionData(state, data) {
+    state.deletionData.push(data)
+  },
+  removeDeletionData(state, idx) {
+    state.deletionData.splice(idx, 1);
+  },
+  resetDeletionData(state) {
+    state.deletionData = [];
   }
 }
 
 export const actions = {
   async getList(context, payload) {
     // console.log('ACTIONS::getList');
-    const docRef = await firebase.firestore().collection('todoItem').doc(payload.uid);
+    const docRef = await fb.firestore().collection('todoItem').doc(payload.uid);
     const docSnapShot = await docRef.get().catch((err) => console.log(err));
     // https://firebase.google.com/docs/reference/js/firebase.firestore.DocumentSnapshot
     // console.log(docSnapShot.get('list'));
     context.commit('setList', docSnapShot.get('list'));
+  },
+  async deleteList(context, payload) {
+    const { uid, data } = payload;
+    const batch = await fb.firestore().batch();
+    const listRef = await fb.firestore().collection('todoItem').doc(uid);
+    const curDisplayList = context.state.data;
+    let indices = [];
+    try {
+      for (const datum of data) {
+        batch.update(listRef, {
+          'list': fb.firestore.FieldValue.arrayRemove(datum)
+        });
+        const docRef = await fb.firestore().collection('todoItem').doc(uid).collection('data').doc(datum.value);
+        batch.delete(docRef);
+        const idx = curDisplayList.findIndex(item => item.value === datum.value);
+        indices.push(idx);
+      }
+      await batch.commit();
+      context.commit('removeList', indices);
+    } catch (err) {
+      console.log(err);
+    }
   }
 }

--- a/src/store/mix-action-controllers.js
+++ b/src/store/mix-action-controllers.js
@@ -1,0 +1,27 @@
+export const state = () => ({
+  isActived: false,
+  buttons: {
+    add: true,
+    del: false,
+  }
+});
+
+export const mutations = {
+  isActived(state) {
+    state.isActived = !state.isActived;
+  },
+  enableAddbutton(state) {
+    state.buttons.add = true;
+    state.buttons.del = false;
+  },
+  enableDelbutton(state) {
+    state.buttons.add = false;
+    state.buttons.del = true;
+    state.isActived = false;
+  },
+  initializeState(state) {
+    state.isActived = false;
+    state.buttons.add = true;
+    state.buttons.del = false;
+  },
+}

--- a/src/store/todo-item.js
+++ b/src/store/todo-item.js
@@ -3,8 +3,8 @@ const fb = new FirebaseQuery();
 
 export const state = () => ({
   id: 0,
-  currentDataKeyName: 'example',
-  currentTodoname: 'ExampleTODO',
+  currentDataKeyName: '',
+  currentTodoname: '',
   data: [],
   isDeletable: false,
   deletionIds: [],
@@ -87,7 +87,7 @@ export const mutations = {
       state.data.splice(indices[i], 1);
     }
   },
-  switchToDo(state, payload) {
+  setTodoState(state, payload) {
     state.currentDataKeyName = payload.key;
     state.currentTodoname = payload.name;
     state.id = 0;
@@ -98,7 +98,7 @@ export const mutations = {
 export const actions = {
   async createNewData(context, payload) {
     const key = await fb.addNewDoc('todoItem', payload.uid, 'data', payload.todoname);
-    context.commit('switchToDo', { key, name: payload.todoname });
+    context.commit('setTodoState', { key, name: payload.todoname });
   },
   async getTodo(context, payload) {
     const todo = await fb.getStoreData('todoItem',payload.uid, 'data', payload.docId);


### PR DESCRIPTION
## 追加機能

* 計画リストの削除機能を追加
* 計画リストが一件だけの場合は削除できない様 alert を表示
* 計画リストページにアクションを行うボタンを追加
* 計画リストページから計画の新規作成を行える様にした

## 改善事項

* モーダルに backdrop-filler を適応
* footer bar の高さを 6px 増やした
* footer bar に現在選択位置を示唆する border  line の追加
* todo の内容を表示する font-size を 12 から 14 へ変更
* “予定リストの新規作成” から “計画の新規作成”へ文言変更
* footer bar 位置から表示されるアクションの項目を横並びから縦並び表示に変更
* 計画リストから計画を選択した際、自動で内容ページへ移る様にした
* 一番最初ページにアクセスし計画の内容をDBから取得する処理を
ハードコーディングから動的に変更