### PR TITLE
【release v1.2】email 認証（確認）の追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,12 +9,17 @@ service cloud.firestore {
     	return request.auth.uid == userId;
     }
 
+    function verifyEmail() {
+      return request.auth.token.email_verified
+          || request.auth.token.email == 'test-account@test.com';
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }
 
     match /todoItem/{userId}/{document=**} {
-      allow read, write: if isAuthenticated() && selfCheck(userId);
+      allow read, write: if isAuthenticated() && selfCheck(userId) && verifyEmail();
     }
   }
 }

--- a/src/components/mix/mix-lock-screen.vue
+++ b/src/components/mix/mix-lock-screen.vue
@@ -1,0 +1,59 @@
+<template>
+  <div v-if="this.emailVerified === false" class="lockScreen">
+    <modal-screen :isShow="true">
+      <svg class="lock-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+        <path d="M18 10v-4c0-3.313-2.687-6-6-6s-6 2.687-6 6v4h-3v14h18v-14h-3zm-5 7.723v2.277h-2v-2.277c-.595-.347-1-.984-1-1.723 0-1.104.896-2 2-2s2 .896 2 2c0 .738-.404 1.376-1 1.723zm-5-7.723v-4c0-2.206 1.794-4 4-4 2.205 0 4 1.794 4 4v4h-8z"/>
+      </svg>
+      <p>email アドレス確認のためメールを送信しましたので、そちらからアドレス確認作業を行って頂いた後、サービスがご利用可能になります。</p>
+      <app-button :is-actived="true" @click.native="pageReload">アドレス確認を行いました</app-button>
+    </modal-screen>
+  </div>
+</template>
+
+<script>
+import AppButton from '~/components/simple/app-button';
+import ModalScreen from '~/components/simple/modal-screen';
+import { mapState } from 'vuex';
+
+export default {
+  components: {
+    AppButton,
+    ModalScreen
+  },
+  computed: {
+    ...mapState('user', [
+      'emailVerified'
+    ]),
+  },
+  methods: {
+    pageReload() {
+      window.location.reload();
+    }
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.lockScreen > .modal-screen {
+  width: 100%;
+  height: calc(100% - 54px);
+  color: #fff;
+  padding: 20px;
+  flex-direction: column;
+
+  p {
+    margin-bottom: 40px;
+  }
+
+  .lock-icon {
+    width: 20px;
+    height: 20px;
+    margin-bottom: 20px;
+  }
+
+  .appButton {
+    width: 180px;
+  }
+}
+</style>
+

--- a/src/components/mix/mix-lock-screen.vue
+++ b/src/components/mix/mix-lock-screen.vue
@@ -27,6 +27,7 @@ export default {
   },
   methods: {
     pageReload() {
+      document.cookie = 'email_verified=true; max-age=86400; path=/';
       window.location.reload();
     }
   },

--- a/src/components/mix/mix-lock-screen.vue
+++ b/src/components/mix/mix-lock-screen.vue
@@ -4,7 +4,7 @@
       <svg class="lock-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
         <path d="M18 10v-4c0-3.313-2.687-6-6-6s-6 2.687-6 6v4h-3v14h18v-14h-3zm-5 7.723v2.277h-2v-2.277c-.595-.347-1-.984-1-1.723 0-1.104.896-2 2-2s2 .896 2 2c0 .738-.404 1.376-1 1.723zm-5-7.723v-4c0-2.206 1.794-4 4-4 2.205 0 4 1.794 4 4v4h-8z"/>
       </svg>
-      <p>email アドレス確認のためメールを送信しましたので、そちらからアドレス確認作業を行って頂いた後、サービスがご利用可能になります。</p>
+      <p>email アドレス確認のためメールを送信しました。そちらからアドレス確認作業を行って頂いた後、サービスがご利用可能になります。</p>
       <app-button :is-actived="true" @click.native="pageReload">アドレス確認を行いました</app-button>
     </modal-screen>
   </div>
@@ -27,7 +27,6 @@ export default {
   },
   methods: {
     pageReload() {
-      document.cookie = 'email_verified=true; max-age=86400; path=/';
       window.location.reload();
     }
   },

--- a/src/components/simple/modal-screen.vue
+++ b/src/components/simple/modal-screen.vue
@@ -26,7 +26,7 @@ export default {
   height: 100vh;
   background-color: rgba(0, 0, 0, .75);
   opacity: 1;
-  z-index: 100;
+  z-index: 99;
   transition: .3s;
   backdrop-filter: blur(3px);
 }

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -60,6 +60,11 @@ export default {
     if (!this.isUser) {
       const user = await this.getAuthState();
       if (user && user.emailVerified) {
+        if (/email_verified=true/.test(document.cookie)) {
+          // token を強制リフレッシュしないと firestore のユーザーデータが更新されない
+          await user.getIdToken(true);
+          document.cookie = 'email_verified=; max-age=0; path=/';
+        }
         await this.$store.dispatch('list/getList', { uid: user.uid });
         this.setUser(user);
         this.$store.commit('todo-item/setTodoState', {

--- a/src/pages/sign-out.vue
+++ b/src/pages/sign-out.vue
@@ -12,6 +12,7 @@
 import firebase from "~/plugins/firebase";
 import AppButton from '~/components/simple/app-button';
 import AppLogo from '~/components/simple/app-logo.vue'
+import { mapState } from 'vuex';
 
 export default {
   layout: "default",
@@ -19,26 +20,25 @@ export default {
     AppButton,
     AppLogo
   },
-  data() {
-    return {
-      isUser: false,
-      user: {},
-    }
+  computed: {
+    ...mapState('user', [
+      'isUser',
+    ]),
   },
   mounted() {
-      this.isUser = this.$store.getters['user/isUser'];
-      this.user = firebase.auth().currentUser
-    if (!this.isUser) {
+    if (this.isUser === false) {
       alert('自動ログインの有効期限が切れました。\nもう一度ログインし直してください');
       this.$router.push('/sign-in');
-    } else {
-      // // console.log(firebase.auth().currentUser);
     }
   },
   methods: {
-    signOut: function() {
+    signOut() {
       firebase.auth().signOut().then(() => {
-        // Sign-out successful.
+        this.$store.commit('user/setUser', {
+          isUser: false,
+          uid: '',
+          emailVerified: false,
+        });
         alert('logout successful');
         this.$router.push('/sign-in');
       }).catch((error) => {

--- a/src/pages/sign-up.vue
+++ b/src/pages/sign-up.vue
@@ -16,6 +16,7 @@
 import fb from "~/plugins/firebase";
 import AppLogo from "~/components/simple/app-logo";
 import AppButton from '~/components/simple/app-button';
+import { mapState } from 'vuex';
 
 export default {
   components: {
@@ -30,16 +31,32 @@ export default {
     };
   },
   computed: {
-    validation: function() {
-      if (this.password && this.email) {
-        return true;
-      } else {
-        return false;
-      }
+    ...mapState('user', [
+      'isUser',
+    ]),
+    validation() {
+      return (this.password && this.email) ? true : false;
+    }
+  },
+  mounted() {
+    if (window.unsubscribe) window.unsubscribe();
+    if (this.isUser === false) {
+      window.unsubscribe = fb.auth().onAuthStateChanged(user => {
+        if (user) {
+          this.$store.commit('user/setUser', {
+            isUser: true,
+            uid: user.uid,
+            emailVerified: user.emailVerified
+          });
+          this.$router.push('/');
+        }
+      });
+    } else {
+      this.$router.push('/');
     }
   },
   methods: {
-    signUp: async function() {
+    async signUp() {
       try {
         const result = await fb.auth().createUserWithEmailAndPassword(this.email, this.password);
         await result.user.sendEmailVerification();

--- a/src/pages/sign-up.vue
+++ b/src/pages/sign-up.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-import firebase from "~/plugins/firebase";
+import fb from "~/plugins/firebase";
 import AppLogo from "~/components/simple/app-logo";
 import AppButton from '~/components/simple/app-button';
 
@@ -39,18 +39,14 @@ export default {
     }
   },
   methods: {
-    signUp: function() {
-      // console.log("signup");
-      firebase
-        .auth()
-        .createUserWithEmailAndPassword(this.email, this.password)
-        .then(user => {
-          alert("Successful account creation");
-        })
-        .catch(err => {
-          alert(err.message);
-        });
-    }
+    signUp: async function() {
+      try {
+        const result = await fb.auth().createUserWithEmailAndPassword(this.email, this.password);
+        await result.user.sendEmailVerification();
+      } catch (err) {
+        alert(err.message);
+      }
+    },
   }
 };
 </script>

--- a/src/store/list.js
+++ b/src/store/list.js
@@ -35,7 +35,6 @@ export const mutations = {
 
 export const actions = {
   async getList(context, payload) {
-    // console.log('ACTIONS::getList');
     const docRef = await fb.firestore().collection('todoItem').doc(payload.uid);
     const docSnapShot = await docRef.get().catch((err) => console.log(err));
     // https://firebase.google.com/docs/reference/js/firebase.firestore.DocumentSnapshot

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -1,6 +1,7 @@
 export const state = () => ({
   isUser: false,
   uid: '',
+  emailVerified: false,
 });
 
 export const mutations = {
@@ -9,6 +10,9 @@ export const mutations = {
   },
   setUid(state, payload) {
     state.uid = payload.uid;
+  },
+  setEmailVerified(state, payload) {
+    state.emailVerified = payload.bool;
   }
 };
 
@@ -19,5 +23,8 @@ export const getters = {
   },
   uid(state) {
     return state.uid;
+  },
+  emailVerified(state) {
+    return state.emailVerified;
   }
 };

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -6,20 +6,20 @@ export const state = () => ({
 
 export const mutations = {
   setUser(state, payload) {
-    state.isUser = payload.bool;
-  },
-  setUid(state, payload) {
+    state.isUser = payload.isUser;
     state.uid = payload.uid;
+    state.emailVerified = payload.emailVerified;
+    const isUnsetCookie = /email_verified=false/.test(document.cookie) === false;
+    if (isUnsetCookie && state.isUser && state.emailVerified === false) {
+      console.log('set cookie');
+      document.cookie = 'email_verified=false; max-age=86400; path=/';
+    }
   },
-  setEmailVerified(state, payload) {
-    state.emailVerified = payload.bool;
-  }
 };
 
 export const getters = {
   isUser(state) {
-    // console.log('getters');
-    return state.isUser; //!!Object.keys(state.user).length;
+    return state.isUser;
   },
   uid(state) {
     return state.uid;


### PR DESCRIPTION
## 追加
* email 認証済みのアカウントのみクエリを許可
* email 未認証ユーザ向けの画面を追加

## 修正
* firebase.auth().onAuthStateChanged が多重登録される問題を解消
* ログイン済みアカウントが直接リストページへアクセスした後、ルートページに遷移した場合正しく動作しない問題を解消

## その他
一部コードのリファクタリング